### PR TITLE
[MKC-1111] fix broken link

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -123,4 +123,4 @@ void loop1 () {
 
 #### See also
 
-* [Scheduler.startLoop()](#schedulerstartloop)
+* [Scheduler.startLoop()](#scheduler.startloop)


### PR DESCRIPTION
This PR fixes a minor typo in the `See also` section which resulted in a broken link.